### PR TITLE
尝试修复以/:key/:file*模式匹配/bla/aow和/blaaow结果错误的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ const pathToRegexp = path => {
         const r = '([^/]+?)';
         const m = {
           '?': `(?:/${r})?`,
-          '*': '(.*)'
+          '*': '(?:/)(.*)'
         };
         pattern += m[o] || `/${r}`;
         keys.push(p.substring(1, p.length - !!m[o]));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "routing2",
+  "version": "0.0.14",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
访问地址：http://localhost:3002/autofocus
'/:key/:file'

期望：
key: autofocus
file: 
实际：
key: a
file: utofocus